### PR TITLE
fix: session_id

### DIFF
--- a/hivemind_voice_relay/__main__.py
+++ b/hivemind_voice_relay/__main__.py
@@ -17,6 +17,22 @@ from hivemind_voice_relay.service import HiveMindVoiceRelay
 @click.option("--selfsigned", help="accept self signed certificates", is_flag=True)
 @click.option("--siteid", help="location identifier for message.context", type=str, default="")
 def connect(host, key, password, port, selfsigned, siteid):
+    """
+    Start and run the HiveMind Voice Relay service using provided or stored node identity.
+    
+    This function initializes logging, resolves missing credentials from the local NodeIdentity, validates and normalizes the host and port, connects to the HiveMind message bus, starts the voice relay service in a daemon thread, optionally starts PHAL if available, and blocks until an exit signal is received; on exit it stops the relay and shuts down PHAL if started.
+    
+    Parameters:
+        host (str): WebSocket URL or hostname of the HiveMind master (scheme will be prefixed if missing).
+        key (str): Access key for the node; if omitted the value from NodeIdentity is used.
+        password (str): Password for the node; if omitted the value from NodeIdentity is used.
+        port (int): Port to connect to; if omitted the value from NodeIdentity or 5678 is used.
+        selfsigned (bool): Allow connecting to a server with a self-signed TLS certificate when True.
+        siteid (str): Site identifier to register with the bus; if omitted the value from NodeIdentity or "unknown" is used.
+    
+    Raises:
+        RuntimeError: If key, password, or host are not available from arguments or NodeIdentity.
+    """
     init_service_logger("HiveMind-voice-relay")
 
     identity = NodeIdentity()

--- a/hivemind_voice_relay/__main__.py
+++ b/hivemind_voice_relay/__main__.py
@@ -5,7 +5,6 @@ from ovos_utils.log import init_service_logger, LOG
 
 from hivemind_bus_client import HiveMessageBusClient
 from hivemind_bus_client.identity import NodeIdentity
-from ovos_bus_client.session import Session
 from hivemind_voice_relay.service import HiveMindVoiceRelay
 
 

--- a/hivemind_voice_relay/__main__.py
+++ b/hivemind_voice_relay/__main__.py
@@ -5,6 +5,7 @@ from ovos_utils.log import init_service_logger, LOG
 
 from hivemind_bus_client import HiveMessageBusClient
 from hivemind_bus_client.identity import NodeIdentity
+from ovos_bus_client.session import Session
 from hivemind_voice_relay.service import HiveMindVoiceRelay
 
 
@@ -38,16 +39,13 @@ def connect(host, key, password, port, selfsigned, siteid):
         LOG.error(f"ws://{host} or wss://{host}")
         exit(1)
 
-    internal_bus = FakeBus()
-
     # connect to hivemind
     bus = HiveMessageBusClient(key=key,
                                password=password,
                                port=port,
                                host=host,
                                useragent="VoiceRelayV1.0.0",
-                               self_signed=selfsigned,
-                               internal_bus=internal_bus)
+                               self_signed=selfsigned)
     bus.connect(site_id=siteid)
 
     # STT listener thread

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 hivemind_bus_client>=0.0.4
 ovos-audio
-ovos-simple-listener>=0.0.3,<1.0.0
+ovos-simple-listener>=0.0.8,<1.0.0
 ovos-microphone-plugin-alsa
 ovos-vad-plugin-silero
 ovos-stt-plugin-server

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 hivemind_bus_client>=0.0.4
 ovos-audio
-ovos-simple-listener>=0.0.8,<1.0.0
+ovos-simple-listener>=0.1.0,<1.0.0
 ovos-microphone-plugin-alsa
 ovos-vad-plugin-silero
 ovos-stt-plugin-server


### PR DESCRIPTION
let FakeBus be created internally with a unique session_id, no reason to pass it explicitly and doing so sets session to "default"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional PHAL support, automatically activated when available.
  * Implemented graceful shutdown handling on exit signals.

* **Chores**
  * Updated ovos-simple-listener dependency to version >=0.0.8.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->