### PR TITLE
docs: reframe voice-relay around HiveMind-as-a-service

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,19 @@ Voice Relay runs the microphone, VAD, and wakeword engine on-device — keeping 
 | **HiveMind-voice-relay** (this repo) | local | local | **local** | server | server | **core + audio-binary-protocol** |
 | [HiveMind-voice-sat](https://github.com/JarbasHiveMind/HiveMind-voice-sat) | local | local | local | local | local | hivemind-core |
 
-Voice Relay is the middle-ground: wakeword detection stays on-device (low latency, no audio leaves until activation), while the heavier STT and TTS models run on the server.
+Voice Relay keeps wakeword detection on-device (low latency, no audio leaves until activation) while STT and TTS run on the hive. The point is not mainly resource savings — it is **what it means for the hive to own speech services** (see below).
+
+---
+
+## Why voice-relay — HiveMind as a service
+
+Voice-relay's real lesson is architectural. STT and TTS run *inside the hive* (the `hivemind-audio-binary-protocol` plugin on `hivemind-core`) and sit **behind the same access-key authentication** as the rest of the mesh. For a developer, the consequences matter more than the saved CPU:
+
+- **The hive owns STT/TTS.** A [voice-sat](https://github.com/JarbasHiveMind/HiveMind-voice-sat) can point at any STT/TTS plugin it likes — including a public `ovos-stt-plugin-server` / `ovos-tts-plugin-server`. A relay **cannot**: it does not choose the engine, model, or voice. The **hive operator decides**, centrally and uniformly, for every relay that connects.
+- **Speech is authenticated.** STT/TTS are not an open endpoint anyone can hit — access is gated by the client's HiveMind credentials, exactly like every other message on the protocol.
+- **It is the reference for the b64 speech API.** The relay sends audio for STT and receives speech for TTS as base64-encoded WAV over the HiveMessage bus (`recognizer_loop:b64_transcribe`, `speak:b64_audio`) — the same work [mic-satellite](https://github.com/JarbasHiveMind/hivemind-mic-satellite) does over the binary protocol. Relay illustrates the b64 path; it could equally use binary.
+
+Choose voice-relay when you want HiveMind to operate STT/TTS as a **governed, authenticated service** — uniform and centrally controlled — with wakeword kept local for latency and privacy. Lower device resource use is a consequence, not the goal.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -117,6 +117,16 @@ Connecting voice-relay to a plain `hivemind-core` node will result in wakeword t
 
 ---
 
+## HiveMind as a service: ownership and authentication
+
+This is the part that matters most from a developer's perspective — beyond moving compute off the device, voice-relay shows HiveMind operating speech as an owned, governed service.
+
+**The hive owns STT/TTS; the satellite cannot choose them.** The relay never names an STT or TTS engine. It emits `recognizer_loop:b64_transcribe` and `speak:b64_audio` and takes whatever the hive returns. Which STT/TTS plugin, which model, which voice — all of that is configured once on `hivemind-core` (in the `hivemind-audio-binary-protocol` plugin's OVOS config) and applied uniformly to every relay that connects. Contrast a [voice-sat](https://github.com/JarbasHiveMind/HiveMind-voice-sat), which runs its own STT/TTS plugins and can point at any endpoint it likes — including a public `ovos-stt-plugin-server` / `ovos-tts-plugin-server`. The relay deliberately gives that control up to the operator.
+
+**Speech is behind auth.** Because STT/TTS live inside the hive, they inherit the protocol's access-key authentication. They are not an open network service anyone can call — a client must be a credentialed member of the mesh to transcribe or synthesise. A public OVOS plugin server has no such gate; HiveMind makes speech a first-class, authenticated capability of the hive itself.
+
+**b64 vs binary — the same job, two transports.** The relay carries audio as base64-encoded WAV over the JSON bus (`b64_transcribe` / `b64_audio`). [mic-satellite](https://github.com/JarbasHiveMind/hivemind-mic-satellite) does the equivalent over the binary protocol (`HiveMessageType.BINARY` / `RAW_AUDIO`), which avoids the ~33% base64 overhead. Relay is the reference implementation for the b64 path; it could be built on the binary protocol instead. Choose b64 for simplicity and debuggability, binary for bandwidth.
+
 ## PHAL (optional)
 
 If `ovos-PHAL` is installed, the relay loads it using the HiveMind bus as its internal bus:

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@
 
 HiveMind Voice Relay is a satellite client for the HiveMind mesh. It runs the microphone, voice-activity detection (VAD), and wakeword engine on-device, but forwards audio to **hivemind-core** running the **hivemind-audio-binary-protocol** plugin for speech-to-text (STT). The server synthesises speech (TTS) and sends audio back for local playback.
 
-This makes it the middle-ground option: wakeword privacy and low activation latency without the resource cost of running STT/TTS models locally.
+The point is architectural, not just resource savings: **the hive owns STT/TTS**. They run inside `hivemind-core` (via the `hivemind-audio-binary-protocol` plugin), **behind the same access-key authentication** as the rest of the mesh — so a relay does not, and cannot, choose its own STT/TTS engine, model, or voice. The hive operator decides, centrally, for every relay. (Contrast a [voice-sat](https://github.com/JarbasHiveMind/HiveMind-voice-sat), which can point at any plugin, including a public `ovos-stt-plugin-server`.) Relay also demonstrates the **base64 speech API** (`recognizer_loop:b64_transcribe` / `speak:b64_audio`) — the same job [mic-satellite](https://github.com/JarbasHiveMind/hivemind-mic-satellite) does over the binary protocol.
 
 ---
 
@@ -22,8 +22,9 @@ This makes it the middle-ground option: wakeword privacy and low activation late
 | [HiveMind-voice-sat](https://github.com/JarbasHiveMind/HiveMind-voice-sat) | local | local | local | local | local | hivemind-core |
 
 **Choose voice-relay when:**
-- You want wakeword detection to happen on-device (latency, privacy — audio is not streamed until activation).
-- You do not want to run STT or TTS models on the device (CPU/memory constraints).
+- You want HiveMind to **own and govern STT/TTS as an authenticated service** — uniform engine/model/voice across all relays, decided by the hive operator, not the device.
+- You want wakeword detection on-device (latency, privacy — audio is not streamed until activation).
+- You do not want to run STT or TTS models on the device (a welcome consequence, not the main reason).
 - Your `hivemind-core` server has the `hivemind-audio-binary-protocol` plugin installed.
 
 ---


### PR DESCRIPTION
Shifts the framing from resource-saving to **HiveMind owning STT/TTS as an authenticated service**: the hive (not the satellite) chooses the STT/TTS engine/model/voice; speech is gated behind access-key auth (unlike a public ovos-stt-plugin-server); relay is the reference for the b64 speech API (mic-satellite does the same over binary). (Stranded on the squash-merged #20 branch — re-landing off dev.)