### PR TITLE
test(e2e): refresh hivescope pin 0.3.0a1→0.5.0a2; move policy pins into pyproject

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -11,6 +11,6 @@ jobs:
     with:
       python_versions: '["3.10", "3.11", "3.12", "3.13"]'
       system_deps: 'libasound2-dev'
-      # policy-stack pin: switch hivemind-core to released once #89 merges to dev
-      pre_install_pip: '"hivescope==0.3.0a1" "hivemind-plugin-manager==0.6.0a1" "hivemind-ovos-agent-plugin==0.2.0a1" "hivemind-core==4.3.0a2"'
+      # version policy is in pyproject (the `test` extra); no pre_install pins here.
+      install_extras: 'test'
       test_path: 'tests/'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,6 +13,6 @@ jobs:
       coverage_source: 'hivemind_voice_relay'
       test_path: 'tests/'
       system_deps: 'libasound2-dev'
-      # policy-stack pin: switch hivemind-core to released once #89 merges to dev
-      pre_install_pip: '"hivescope==0.3.0a1" "hivemind-plugin-manager==0.6.0a1" "hivemind-ovos-agent-plugin==0.2.0a1" "hivemind-core==4.3.0a2"'
+      # version policy is in pyproject (the `test` extra); no pre_install pins here.
+      test_extras: 'test'
       min_coverage: 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,20 @@ requires-python = ">=3.10"
 dynamic = ["version", "dependencies"]
 
 [project.optional-dependencies]
-test = ["pytest", "pytest-timeout", "hivescope==0.3.0a3"]
+# Test/e2e deps. Pinned to the bus-client 1.x world: the relay's ovos-audio /
+# ovos-simple-listener runtime deps require ovos-bus-client<2.0.0, so core and
+# the agent plugin stay on their last 1.x-compatible alphas (the 2.x successors
+# require ovos-bus-client>=2.0.0a3 and would conflict). hivescope 0.5.0a2
+# resolves on 1.x via hivemind-bus-client 0.9.1a1. Bump once ovos-audio /
+# ovos-simple-listener support ovos-bus-client 2.x.
+test = [
+    "pytest",
+    "pytest-timeout",
+    "hivescope==0.5.0a2",
+    "hivemind-core==4.3.0a2",
+    "hivemind-ovos-agent-plugin==0.2.0a1",
+    "hivemind-plugin-manager==0.6.0a1",
+]
 
 [project.urls]
 Homepage = "https://github.com/JarbasHiveMind/HiveMind-voice-relay"


### PR DESCRIPTION
Refreshes the ACL e2e policy-stack pins and moves them out of CI into pyproject.

- bump `hivescope` 0.3.0a1/0.3.0a3 → **0.5.0a2** (the current published e2e library)
- move the policy-stack pins (hivescope, hivemind-core, hivemind-ovos-agent-plugin, hivemind-plugin-manager) out of the workflows' `pre_install_pip` and into the pyproject `test` extra; CI installs them via `install_extras`/`test_extras`. Keeps version policy in pyproject (org convention).

Stays on the **bus-client 1.x** stack on purpose: the runtime audio deps (ovos-audio / ovos-simple-listener / ovos-dinkum-listener) still cap `ovos-bus-client<2.0.0`, so core/agent-plugin stay on their last 1.x-compatible alphas. hivescope 0.5.0a2 resolves on 1.x via hivemind-bus-client 0.9.1a1.

Same change as HiveMind-voice-sat#64. Part of the HiveMind cluster e2e/CI modernization sweep.