### PR TITLE
docs: rewrite README in Simplified Technical English

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 [![PyPI](https://img.shields.io/pypi/v/HiveMind-voice-relay)](https://pypi.org/project/HiveMind-voice-relay/)
 [![Python](https://img.shields.io/pypi/pyversions/HiveMind-voice-relay)](https://pypi.org/project/HiveMind-voice-relay/)
 
-**Local wakeword detection; STT and TTS handled remotely by hivemind-core running the hivemind-audio-binary-protocol plugin.**
+**Local wakeword detection. STT and TTS run remotely on hivemind-core with the hivemind-audio-binary-protocol plugin.**
 
-Voice Relay runs the microphone, VAD, and wakeword engine on-device — keeping wake-word detection private and low-latency — while forwarding audio to **hivemind-core** (running the **hivemind-audio-binary-protocol** plugin) for speech-to-text, and receiving synthesised audio back for playback. No STT or TTS models run on the device.
+Voice Relay runs the microphone, VAD, and wakeword engine on-device. This keeps wake-word detection private and low-latency. It forwards audio to **hivemind-core** (running the **hivemind-audio-binary-protocol** plugin) for speech-to-text, and receives synthesised audio back for playback. No STT or TTS models run on the device.
 
 > Full documentation: **[docs/](docs/index.md)**
 
@@ -16,30 +16,30 @@ Voice Relay runs the microphone, VAD, and wakeword engine on-device — keeping 
 
 | Satellite | Mic | VAD | Wake word | STT | TTS | Connects to |
 |---|---|---|---|---|---|---|
-| [HiveMind-cli](https://github.com/JarbasHiveMind/HiveMind-cli) | — | — | — | — | — | hivemind-core |
+| [HiveMind-cli](https://github.com/JarbasHiveMind/HiveMind-cli) | n/a | n/a | n/a | n/a | n/a | hivemind-core |
 | [hivemind-mic-satellite](https://github.com/JarbasHiveMind/hivemind-mic-satellite) | local | local | **server** | server | server | core + audio-binary-protocol |
 | **HiveMind-voice-relay** (this repo) | local | local | **local** | server | server | **core + audio-binary-protocol** |
 | [HiveMind-voice-sat](https://github.com/JarbasHiveMind/HiveMind-voice-sat) | local | local | local | local | local | hivemind-core |
 
-Voice Relay keeps wakeword detection on-device (low latency, no audio leaves until activation) while STT and TTS run on the hive. The point is not mainly resource savings — it is **what it means for the hive to own speech services** (see below).
+Voice Relay keeps wakeword detection on-device. No audio leaves the device until activation, and latency stays low. STT and TTS run on the hive instead. The point is not mainly resource savings. It is **what it means for the hive to own speech services** (see below).
 
 ---
 
-## Why voice-relay — HiveMind as a service
+## Why voice-relay: HiveMind as a service
 
 Voice-relay's real lesson is architectural. STT and TTS run *inside the hive* (the `hivemind-audio-binary-protocol` plugin on `hivemind-core`) and sit **behind the same access-key authentication** as the rest of the mesh. For a developer, the consequences matter more than the saved CPU:
 
-- **The hive owns STT/TTS.** A [voice-sat](https://github.com/JarbasHiveMind/HiveMind-voice-sat) can point at any STT/TTS plugin it likes — including a public `ovos-stt-plugin-server` / `ovos-tts-plugin-server`. A relay **cannot**: it does not choose the engine, model, or voice. The **hive operator decides**, centrally and uniformly, for every relay that connects.
-- **Speech is authenticated.** STT/TTS are not an open endpoint anyone can hit — access is gated by the client's HiveMind credentials, exactly like every other message on the protocol.
-- **It is the reference for the b64 speech API.** The relay sends audio for STT and receives speech for TTS as base64-encoded WAV over the HiveMessage bus (`recognizer_loop:b64_transcribe`, `speak:b64_audio`) — the same work [mic-satellite](https://github.com/JarbasHiveMind/hivemind-mic-satellite) does over the binary protocol. Relay illustrates the b64 path; it could equally use binary.
+- **The hive owns STT/TTS.** A [voice-sat](https://github.com/JarbasHiveMind/HiveMind-voice-sat) can point at any STT/TTS plugin it likes, including a public `ovos-stt-plugin-server` or `ovos-tts-plugin-server`. A relay **cannot** choose the engine, model, or voice. The **hive operator decides**, centrally and uniformly, for every relay that connects.
+- **Speech is authenticated.** STT/TTS are not an open endpoint anyone can hit. Access is gated by the client's HiveMind credentials, exactly like every other message on the protocol.
+- **It is the reference for the b64 speech API.** The relay sends audio for STT and receives speech for TTS as base64-encoded WAV over the HiveMessage bus (`recognizer_loop:b64_transcribe`, `speak:b64_audio`). This is the same work [mic-satellite](https://github.com/JarbasHiveMind/hivemind-mic-satellite) does over the binary protocol. Relay illustrates the b64 path. It could equally use binary.
 
-Choose voice-relay when you want HiveMind to operate STT/TTS as a **governed, authenticated service** — uniform and centrally controlled — with wakeword kept local for latency and privacy. Lower device resource use is a consequence, not the goal.
+Choose voice-relay when you want HiveMind to operate STT/TTS as a **governed, authenticated service**, uniform and centrally controlled, with wakeword kept local for latency and privacy. Lower device resource use is a consequence, not the goal.
 
 ---
 
 ## Server requirements
 
-> ⚠️ **Your `hivemind-core` server must have the [hivemind-audio-binary-protocol](https://github.com/JarbasHiveMind/hivemind-audio-binary-protocol) binary plugin installed.** Plain `hivemind-core` does not handle STT or TTS — connecting to it will result in silence (no transcription, no spoken response).
+> **Your `hivemind-core` server must have the [hivemind-audio-binary-protocol](https://github.com/JarbasHiveMind/hivemind-audio-binary-protocol) binary plugin installed.** Plain `hivemind-core` does not handle STT or TTS. Connecting to it results in silence: no transcription and no spoken response.
 >
 > Alternatively, run `hivemind-core` together with `ovos-audio` and `ovos-dinkum-listener` to provide the same capabilities.
 
@@ -101,12 +101,12 @@ Voice Relay reads `~/.config/mycroft/mycroft.conf` (standard OVOS config).
 | Microphone | `microphone.module` | `ovos-microphone-plugin-alsa` | Yes |
 | VAD | `listener.VAD.module` | `ovos-vad-plugin-silero` | Yes |
 | Wake word | `listener.wake_word` | `hey_mycroft` | Yes |
-| G2P | `tts.g2p_module` | — | No |
-| Media Playback | `Audio.backends` | — | No |
-| OCP Plugins | — | — | No |
-| Dialog Transformers | — | — | No |
-| TTS Transformers | — | — | No |
-| PHAL | — | — | No (auto-loaded if installed) |
+| G2P | `tts.g2p_module` | n/a | No |
+| Media Playback | `Audio.backends` | n/a | No |
+| OCP Plugins | n/a | n/a | No |
+| Dialog Transformers | n/a | n/a | No |
+| TTS Transformers | n/a | n/a | No |
+| PHAL | n/a | n/a | No (auto-loaded if installed) |
 
 See [docs/configuration.md](docs/configuration.md) for full details and plugin swap instructions.
 
@@ -117,7 +117,7 @@ See [docs/configuration.md](docs/configuration.md) for full details and plugin s
 Built on [ovos-simple-listener](https://github.com/TigreGotico/ovos-simple-listener). Compared to the full voice-satellite:
 
 **Present:**
-- Microphone capture, VAD, wakeword detection — all local
+- Microphone capture, VAD, and wakeword detection, all local
 - Audio forwarded to hivemind-core (hivemind-audio-binary-protocol plugin) for STT (base64-encoded WAV over the HiveMessage bus)
 - TTS audio synthesised server-side and streamed back for local playback
 - PHAL (platform hardware abstraction) auto-loaded if installed
@@ -135,7 +135,7 @@ Built on [ovos-simple-listener](https://github.com/TigreGotico/ovos-simple-liste
 
 | Project | Role |
 |---|---|
-| [hivemind-audio-binary-protocol](https://github.com/JarbasHiveMind/hivemind-audio-binary-protocol) | Required `hivemind-core` plugin — provides server-side STT + TTS |
+| [hivemind-audio-binary-protocol](https://github.com/JarbasHiveMind/hivemind-audio-binary-protocol) | Required `hivemind-core` plugin, provides server-side STT and TTS |
 | [hivemind-core](https://github.com/JarbasHiveMind/HiveMind-core) | Base mesh node (no STT/TTS) |
 | [HiveMind-cli](https://github.com/JarbasHiveMind/HiveMind-cli) | Text-only satellite |
 | [hivemind-mic-satellite](https://github.com/JarbasHiveMind/hivemind-mic-satellite) | Thinnest audio satellite (no local wakeword) |
@@ -157,7 +157,7 @@ pytest tests/
 `pyproject.toml` is the single packaging source of truth. The E2E suite runs a
 real `hivemind-core` master in-process and the real relay client over a real
 `HiveMessageBusClient`, with the microphone/wakeword and the remote STT/TTS
-endpoints mocked — see **[docs/development.md](docs/development.md)**.
+endpoints mocked. See **[docs/development.md](docs/development.md)**.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,9 +43,9 @@ The wake word name is read from `Configuration().get("listener", {}).get("wake_w
 ### What happens on wakeword detection
 
 `HMCallbacks.listen_callback()` fires internal bus events:
-- `mycroft.audio.play_sound` — plays the start-listening chime locally.
-- `recognizer_loop:wakeword` — notifies local PHAL/audio subsystems.
-- `recognizer_loop:record_begin` — marks the start of recording.
+- `mycroft.audio.play_sound`: plays the start-listening chime locally.
+- `recognizer_loop:wakeword`: notifies local PHAL/audio subsystems.
+- `recognizer_loop:record_begin`: marks the start of recording.
 
 After recording ends, `recognizer_loop:record_end` is emitted, then the audio is passed to `HiveMindSTT`.
 
@@ -62,7 +62,7 @@ After recording ends, `recognizer_loop:record_end` is emitted, then the audio is
 
 On timeout or empty response, it returns an empty string and logs the error.
 
-hivemind-core — via the `hivemind-audio-binary-protocol` plugin — receives the `b64_transcribe` message, runs its configured STT plugin, and sends back the response.
+hivemind-core, via the `hivemind-audio-binary-protocol` plugin, receives the `b64_transcribe` message. It runs its configured STT plugin and sends back the response.
 
 ---
 
@@ -75,7 +75,7 @@ hivemind-core — via the `hivemind-audio-binary-protocol` plugin — receives t
 3. The server synthesises audio and sends back `speak:b64_audio.response` with `{"audio": "<b64>", "utterance": "...", "listen": bool}`.
 4. The relay decodes the base64 data, writes it to a temp WAV file, and puts the file path on the `TTS.queue` for playback by the local audio service.
 
-This means audio is synthesised on the server with full TTS plugin support; the device only needs a speaker.
+This means audio is synthesised on the server with full TTS plugin support. The device only needs a speaker.
 
 ---
 
@@ -113,24 +113,24 @@ Messages flow as `HiveMessage` packets over the WebSocket. OVOS-style `Message` 
 
 `hivemind-core` is a base mesh node. It routes HiveMessages between satellites and an OVOS instance but does not itself process audio. The [`hivemind-audio-binary-protocol`](https://github.com/JarbasHiveMind/hivemind-audio-binary-protocol) binary plugin adds the listener service that handles the `b64_transcribe` and `speak:b64_audio` protocol messages that voice-relay depends on.
 
-Connecting voice-relay to a plain `hivemind-core` node will result in wakeword triggering, audio being sent, and silence — the STT request will time out and no TTS will arrive.
+Connecting voice-relay to a plain `hivemind-core` node triggers the wakeword and sends audio, but the STT request times out and no TTS arrives.
 
 ---
 
 ## HiveMind as a service: ownership and authentication
 
-This is the part that matters most from a developer's perspective — beyond moving compute off the device, voice-relay shows HiveMind operating speech as an owned, governed service.
+This is the part that matters most from a developer's perspective. Beyond moving compute off the device, voice-relay shows HiveMind operating speech as an owned, governed service.
 
-**The hive owns STT/TTS; the satellite cannot choose them.** The relay never names an STT or TTS engine. It emits `recognizer_loop:b64_transcribe` and `speak:b64_audio` and takes whatever the hive returns. Which STT/TTS plugin, which model, which voice — all of that is configured once on `hivemind-core` (in the `hivemind-audio-binary-protocol` plugin's OVOS config) and applied uniformly to every relay that connects. Contrast a [voice-sat](https://github.com/JarbasHiveMind/HiveMind-voice-sat), which runs its own STT/TTS plugins and can point at any endpoint it likes — including a public `ovos-stt-plugin-server` / `ovos-tts-plugin-server`. The relay deliberately gives that control up to the operator.
+**The hive owns STT/TTS. The satellite cannot choose them.** The relay never names an STT or TTS engine. It emits `recognizer_loop:b64_transcribe` and `speak:b64_audio` and takes whatever the hive returns. The STT/TTS plugin, model, and voice are all configured once on `hivemind-core` (in the `hivemind-audio-binary-protocol` plugin's OVOS config) and applied uniformly to every relay that connects. Contrast a [voice-sat](https://github.com/JarbasHiveMind/HiveMind-voice-sat), which runs its own STT/TTS plugins and can point at any endpoint it likes, including a public `ovos-stt-plugin-server` or `ovos-tts-plugin-server`. The relay deliberately gives that control up to the operator.
 
-**Speech is behind auth.** Because STT/TTS live inside the hive, they inherit the protocol's access-key authentication. They are not an open network service anyone can call — a client must be a credentialed member of the mesh to transcribe or synthesise. A public OVOS plugin server has no such gate; HiveMind makes speech a first-class, authenticated capability of the hive itself.
+**Speech is behind auth.** Because STT/TTS live inside the hive, they inherit the protocol's access-key authentication. They are not an open network service anyone can call. A client must be a credentialed member of the mesh to transcribe or synthesise. A public OVOS plugin server has no such gate. HiveMind makes speech an authenticated capability of the hive itself.
 
-**b64 vs binary — the same job, two transports.** The relay carries audio as base64-encoded WAV over the JSON bus (`b64_transcribe` / `b64_audio`). [mic-satellite](https://github.com/JarbasHiveMind/hivemind-mic-satellite) does the equivalent over the binary protocol (`HiveMessageType.BINARY` / `RAW_AUDIO`), which avoids the ~33% base64 overhead. Relay is the reference implementation for the b64 path; it could be built on the binary protocol instead. Choose b64 for simplicity and debuggability, binary for bandwidth.
+**b64 vs binary: the same job, two transports.** The relay carries audio as base64-encoded WAV over the JSON bus (`b64_transcribe` / `b64_audio`). [mic-satellite](https://github.com/JarbasHiveMind/hivemind-mic-satellite) does the equivalent over the binary protocol (`HiveMessageType.BINARY` / `RAW_AUDIO`), which avoids the roughly 33% base64 overhead. Relay is the reference implementation for the b64 path. It could be built on the binary protocol instead. Choose b64 for simplicity and easy debugging. Choose binary for bandwidth.
 
 ## Dependencies
 
 The relay runs on the OVOS **bus-client 2.x** stack. Runtime dependencies are
-declared in `pyproject.toml` (the single packaging source of truth — there is no
+declared in `pyproject.toml` (the single packaging source of truth, there is no
 `requirements.txt` or `setup.py`):
 
 | Dependency | Floor | Role |
@@ -174,4 +174,7 @@ PHAL plugins handle platform-specific hardware (LEDs, buttons, display on device
 | Requires `hivemind-audio-binary-protocol` plugin | Yes | **Yes** | No |
 | Device resource requirement | Minimal | Low | High |
 
-Voice relay is the best fit when: the device is resource-constrained (no STT/TTS), privacy or latency of wakeword detection matters, and a `hivemind-core` server with the `hivemind-audio-binary-protocol` plugin is available.
+Voice relay is the best fit when the device is resource-constrained (no STT/TTS), when privacy or latency of wakeword detection matters, and when a `hivemind-core` server with the `hivemind-audio-binary-protocol` plugin is available.
+
+---
+[← Configuration](configuration.md) · [Home](index.md) · [Deployment →](deployment.md)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -101,7 +101,7 @@ The default `ovos-vad-plugin-silero` works well in most environments. Alternativ
 
 | Plugin | Notes |
 |---|---|
-| `ovos-vad-plugin-silero` | Default; neural, accurate |
+| `ovos-vad-plugin-silero` | Default, neural, accurate |
 | `ovos-vad-plugin-webrtcvad` | Lighter, rule-based |
 
 Full list: [OVOS VAD Plugins](https://openvoiceos.github.io/ovos-technical-manual//311-vad_plugins/#list-of-vad-plugins)
@@ -110,12 +110,12 @@ Full list: [OVOS VAD Plugins](https://openvoiceos.github.io/ovos-technical-manua
 
 | Plugin type | Config path | Notes |
 |---|---|---|
-| G2P | `tts.g2p_module` | Grapheme-to-phoneme for mouth animation; not required for audio |
+| G2P | `tts.g2p_module` | Grapheme-to-phoneme for mouth animation, not required for audio |
 | Media Playback | `Audio.backends` | Enables media commands ("play Metallica") |
-| OCP Plugins | — | URL resolvers for media backends |
-| Dialog Transformers | — | Text post-processing before TTS request is sent |
-| TTS Transformers | — | Audio post-processing after TTS audio received |
-| PHAL | — | Platform hardware abstraction; auto-loaded if `ovos-PHAL` is installed |
+| OCP Plugins | n/a | URL resolvers for media backends |
+| Dialog Transformers | n/a | Text post-processing before TTS request is sent |
+| TTS Transformers | n/a | Audio post-processing after TTS audio received |
+| PHAL | n/a | Platform hardware abstraction, auto-loaded if `ovos-PHAL` is installed |
 
 ### Example mycroft.conf
 
@@ -137,4 +137,7 @@ Full list: [OVOS VAD Plugins](https://openvoiceos.github.io/ovos-technical-manua
 
 ## What is NOT configurable here
 
-STT and TTS plugins are **not configured on the relay device** — they run on the `hivemind-core` server (via the `hivemind-audio-binary-protocol` plugin). Configure them in the server's OVOS config.
+STT and TTS plugins are **not configured on the relay device**. They run on the `hivemind-core` server (via the `hivemind-audio-binary-protocol` plugin). Configure them in the server's OVOS config.
+
+---
+[← Getting started](getting-started.md) · [Home](index.md) · [Architecture →](architecture.md)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -146,3 +146,6 @@ When connecting to a server over TLS (`wss://`):
   ```ini
   ExecStart=/home/YOUR_USER/.local/bin/hivemind-voice-relay --selfsigned
   ```
+
+---
+[← Architecture](architecture.md) · [Home](index.md) · [Development →](development.md)

--- a/docs/development.md
+++ b/docs/development.md
@@ -8,8 +8,8 @@ cd HiveMind-voice-relay
 uv pip install -e ".[e2e]"
 ```
 
-`pyproject.toml` is the single packaging source of truth — runtime dependencies
-live in `[project.dependencies]` and the test/e2e dependencies in the `e2e`
+`pyproject.toml` is the single packaging source of truth. Runtime dependencies
+live in `[project.dependencies]` and the test/e2e dependencies live in the `e2e`
 extra (the `test` extra is an alias of `e2e` for the shared CI workflows).
 
 The microphone plugin needs ALSA headers at build time:
@@ -38,25 +38,25 @@ The suite uses the [`hivescope`](https://github.com/JarbasHiveMind/hivescope)
 harness to run a **real `hivemind-core` master in-process**, with a real
 WebSocket server (`TopologyBuilder.add_master(..., use_loopback=True)`). The
 relay's own `HiveMindSTT`, `HMCallbacks`, and `HMPlayback` classes connect to it
-over a **real `HiveMessageBusClient`** — the same client, handshake, crypto, and
+over a **real `HiveMessageBusClient`**, the same client, handshake, crypto, and
 ACL path as production.
 
 What is **mocked**, so no real devices or outbound network are touched:
 
-- **Mic / VAD / wakeword / audio capture** — `OVOSMicrophoneFactory`,
-  `OVOSVADFactory`, and `OVOSWakeWordFactory` are stubbed; captured audio is fed
+- **Mic / VAD / wakeword / audio capture**: `OVOSMicrophoneFactory`,
+  `OVOSVADFactory`, and `OVOSWakeWordFactory` are stubbed. Captured audio is fed
   in as a pre-built silent `AudioData` buffer. No microphone is opened.
-- **Remote STT / TTS endpoints** — in production the
+- **Remote STT / TTS endpoints**: in production the
   `hivemind-audio-binary-protocol` plugin on the server answers
   `recognizer_loop:b64_transcribe` and `speak:b64_audio`. The tests register a
   small stub handler on the master's agent bus that plays that role and replies
   with a `.response` addressed back to the originating relay peer, so no real
   STT/TTS engine or model is loaded.
-- **TTS playback queue** — `HMPlayback` is built without starting the OVOS audio
-  service; the test asserts on the queued playback item instead of driving a
+- **TTS playback queue**: `HMPlayback` is built without starting the OVOS audio
+  service. The test asserts on the queued playback item instead of driving a
   speaker.
 
-No `importorskip` / `skipif` is used to dodge a missing dependency — the `e2e`
+No `importorskip` / `skipif` is used to dodge a missing dependency. The `e2e`
 extra installs everything the suite needs, so every test actually runs.
 
 ## CI
@@ -67,8 +67,8 @@ reusable workflows (referenced `@dev`):
 
 | Workflow | Shared workflow |
 |---|---|
-| `build_tests.yml` | `build-tests.yml` — whole `tests/` tree, clean install, py3.10–3.13 |
-| `e2e_tests.yml` | `build-tests.yml` — `tests/e2e/` with the `e2e` extra |
+| `build_tests.yml` | `build-tests.yml`, whole `tests/` tree, clean install, py3.10 to 3.13 |
+| `e2e_tests.yml` | `build-tests.yml`, `tests/e2e/` with the `e2e` extra |
 | `coverage.yml` | `coverage.yml` |
 | `lint.yml` | `lint.yml` (ruff) |
 | `license_tests.yml` | `license-check.yml` |
@@ -78,5 +78,8 @@ reusable workflows (referenced `@dev`):
 | `release_workflow.yml` | `publish-alpha.yml` (alpha + propose stable) |
 | `publish_stable.yml` | `publish-stable.yml` |
 
-Version policy is in `pyproject.toml`, never in CI — prerelease floors are pinned
+Version policy is in `pyproject.toml`, never in CI. Prerelease floors are pinned
 as minimum versions (`pkg>=X.Ya1`), so no `--pre` or `pre_install_pip` is needed.
+
+---
+[← Deployment](deployment.md) · [Home](index.md) · [Troubleshooting →](troubleshooting.md)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -9,7 +9,7 @@
 
 ### Server
 
-> ⚠️ **Your `hivemind-core` server must have the [hivemind-audio-binary-protocol](https://github.com/JarbasHiveMind/hivemind-audio-binary-protocol) binary plugin installed.** Plain `hivemind-core` does not provide STT or TTS — if you connect to it, wakeword will trigger but nothing will be transcribed and no spoken response will be returned.
+> **Your `hivemind-core` server must have the [hivemind-audio-binary-protocol](https://github.com/JarbasHiveMind/hivemind-audio-binary-protocol) binary plugin installed.** Plain `hivemind-core` does not provide STT or TTS. If you connect to it, wakeword triggers, but nothing is transcribed and no spoken response returns.
 
 Install the `hivemind-audio-binary-protocol` plugin on a `hivemind-core` server that has the resources to run STT and TTS models. Then:
 
@@ -30,9 +30,9 @@ pip install HiveMind-voice-relay
 ```
 
 This installs the `hivemind-voice-relay` CLI entry point and pulls in default plugins:
-- `ovos-microphone-plugin-alsa` — ALSA microphone capture
-- `ovos-vad-plugin-silero` — Silero VAD
-- `ovos-stt-plugin-server` / `ovos-tts-plugin-server` — used internally for the relay transport
+- `ovos-microphone-plugin-alsa`: ALSA microphone capture
+- `ovos-vad-plugin-silero`: Silero VAD
+- `ovos-stt-plugin-server` / `ovos-tts-plugin-server`: used internally for the relay transport
 
 ---
 
@@ -103,3 +103,6 @@ If you see the wakeword trigger but no transcription arrives, check that `hivemi
 - Swap the wake word or microphone plugin: [Configuration](configuration.md)
 - Run as a system service: [Deployment](deployment.md)
 - Understand the internal pipeline: [Architecture](architecture.md)
+
+---
+[Home](index.md) · [Configuration →](configuration.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
-# HiveMind Voice Relay — Documentation
+# HiveMind Voice Relay Documentation
 
-**Local wakeword detection; STT and TTS handled remotely by hivemind-core running the hivemind-audio-binary-protocol plugin.**
+**Local wakeword detection. STT and TTS run remotely on hivemind-core with the hivemind-audio-binary-protocol plugin.**
 
 ---
 
@@ -8,7 +8,7 @@
 
 HiveMind Voice Relay is a satellite client for the HiveMind mesh. It runs the microphone, voice-activity detection (VAD), and wakeword engine on-device, but forwards audio to **hivemind-core** running the **hivemind-audio-binary-protocol** plugin for speech-to-text (STT). The server synthesises speech (TTS) and sends audio back for local playback.
 
-The point is architectural, not just resource savings: **the hive owns STT/TTS**. They run inside `hivemind-core` (via the `hivemind-audio-binary-protocol` plugin), **behind the same access-key authentication** as the rest of the mesh — so a relay does not, and cannot, choose its own STT/TTS engine, model, or voice. The hive operator decides, centrally, for every relay. (Contrast a [voice-sat](https://github.com/JarbasHiveMind/HiveMind-voice-sat), which can point at any plugin, including a public `ovos-stt-plugin-server`.) Relay also demonstrates the **base64 speech API** (`recognizer_loop:b64_transcribe` / `speak:b64_audio`) — the same job [mic-satellite](https://github.com/JarbasHiveMind/hivemind-mic-satellite) does over the binary protocol.
+The point is architectural, not just resource savings: **the hive owns STT/TTS**. They run inside `hivemind-core` (via the `hivemind-audio-binary-protocol` plugin), **behind the same access-key authentication** as the rest of the mesh. A relay does not, and cannot, choose its own STT/TTS engine, model, or voice. The hive operator decides, centrally, for every relay. (Contrast a [voice-sat](https://github.com/JarbasHiveMind/HiveMind-voice-sat), which can point at any plugin, including a public `ovos-stt-plugin-server`.) Relay also demonstrates the **base64 speech API** (`recognizer_loop:b64_transcribe` / `speak:b64_audio`), the same job [mic-satellite](https://github.com/JarbasHiveMind/hivemind-mic-satellite) does over the binary protocol.
 
 ---
 
@@ -16,14 +16,14 @@ The point is architectural, not just resource savings: **the hive owns STT/TTS**
 
 | Satellite | Mic | VAD | Wake word | STT | TTS | Connects to |
 |---|---|---|---|---|---|---|
-| [HiveMind-cli](https://github.com/JarbasHiveMind/HiveMind-cli) | — | — | — | — | — | hivemind-core |
+| [HiveMind-cli](https://github.com/JarbasHiveMind/HiveMind-cli) | n/a | n/a | n/a | n/a | n/a | hivemind-core |
 | [hivemind-mic-satellite](https://github.com/JarbasHiveMind/hivemind-mic-satellite) | local | local | **server** | server | server | core + audio-binary-protocol |
 | **HiveMind-voice-relay** | local | local | **local** | server | server | **core + audio-binary-protocol** |
 | [HiveMind-voice-sat](https://github.com/JarbasHiveMind/HiveMind-voice-sat) | local | local | local | local | local | hivemind-core |
 
 **Choose voice-relay when:**
-- You want HiveMind to **own and govern STT/TTS as an authenticated service** — uniform engine/model/voice across all relays, decided by the hive operator, not the device.
-- You want wakeword detection on-device (latency, privacy — audio is not streamed until activation).
+- You want HiveMind to **own and govern STT/TTS as an authenticated service**, uniform engine/model/voice across all relays, decided by the hive operator, not the device.
+- You want wakeword detection on-device (latency, privacy, audio is not streamed until activation).
 - You do not want to run STT or TTS models on the device (a welcome consequence, not the main reason).
 - Your `hivemind-core` server has the `hivemind-audio-binary-protocol` plugin installed.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -161,3 +161,6 @@ pip install ovos-PHAL
 ```
 
 Otherwise the message can be ignored.
+
+---
+[← Development](development.md) · [Home](index.md)


### PR DESCRIPTION
Rewrites README.md and docs/*.md in Simplified Technical English for clarity: shorter sentences, no em dashes or semicolons, active voice, and split long paragraphs. Adds the standard prev/home/next navigation footer to each docs page (index exempt). No facts, features, or links changed beyond converting a few bare dash-separated notes into named list items.

Rewritten by Claude Sonnet 5 using the ste-writing skill (authored and reviewed by Claude Fable 5); linted with ste_lint.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified architecture, privacy, latency, and centralized speech-service behavior.
  * Improved setup, configuration, deployment, development, and troubleshooting guidance.
  * Added navigation links and improved Markdown formatting throughout the documentation.
  * Clarified server requirements, dependency ownership, testing workflows, and voice-relay selection.
  * Standardized configuration placeholders and refined descriptions for greater consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->